### PR TITLE
35 add easy method to register a single dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ How to use it:
 
 ```typescript
 function registerProviders(this: DependencyRegistry): void {
-  this.container.register(ProviderTokens.MyProvider, {
-    useValue: new MyProvider()
-  });
+  //
+  this.register(RegistryScope.SINGLETON, ProviderTokens.MyProvider, new MyProvider());
 }
 
 export { registerProviders };
 ```
+- check the avaialbe scopes in [RegistryScope](https://github.com/matheusicaro/matheusicaro-node-framework/blob/03c25f8d346c7c6171b7cf9defd1279b388bb3f3/src/configuration/dependency-registries/dependency-registry.ts#L9-L18).
 </details>
 
 <details><summary>2. Start your registry</summary>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.0.10",
+  "version": "1.1.0-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matheusicaro-node-framework",
-      "version": "1.0.10",
+      "version": "1.1.0-next.1",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.1.0-next.2.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matheusicaro-node-framework",
-      "version": "1.1.0-next.2.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.1.0-next.1",
+  "version": "2.0.0-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matheusicaro-node-framework",
-      "version": "1.1.0-next.1",
+      "version": "2.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.1.0-alpha.1.0",
+  "version": "1.1.0-next.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matheusicaro-node-framework",
-      "version": "1.1.0-alpha.1.0",
+      "version": "1.1.0-next.2.0",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.1.0-next.2",
+  "version": "1.1.0-alpha.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matheusicaro-node-framework",
-      "version": "1.1.0-next.2",
+      "version": "1.1.0-alpha.1.0",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "2.0.0-next.1",
+  "version": "1.1.0-next.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matheusicaro-node-framework",
-      "version": "2.0.0-next.1",
+      "version": "1.1.0-next.2",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.1.0-alpha.1.0",
+  "version": "1.1.0-next.2.0",
   "description": "My custom basic configuration setups for a quick build of services and APIs for Node.",
   "author": "@matheusicaro",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.0.10",
+  "version": "1.1.0-next.1",
   "description": "My custom basic configuration setups for a quick build of services and APIs for Node.",
   "author": "@matheusicaro",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "2.0.0-next.1",
+  "version": "1.1.0-next.2",
   "description": "My custom basic configuration setups for a quick build of services and APIs for Node.",
   "author": "@matheusicaro",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.1.0-next.1",
+  "version": "2.0.0-next.1",
   "description": "My custom basic configuration setups for a quick build of services and APIs for Node.",
   "author": "@matheusicaro",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.1.0-next.2.0",
+  "version": "1.1.0",
   "description": "My custom basic configuration setups for a quick build of services and APIs for Node.",
   "author": "@matheusicaro",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matheusicaro-node-framework",
-  "version": "1.1.0-next.2",
+  "version": "1.1.0-alpha.1.0",
   "description": "My custom basic configuration setups for a quick build of services and APIs for Node.",
   "author": "@matheusicaro",
   "license": "MIT",

--- a/src/configuration/dependency-registries/config-registries.ts
+++ b/src/configuration/dependency-registries/config-registries.ts
@@ -15,7 +15,6 @@ function registerConfigs(this: DependencyRegistry, disableDefaultInstances?: Dis
    */
 
   if (!disableDefaultInstances?.loggerDisabled) {
-    console.log('====> passed here', disableDefaultInstances?.loggerDisabled);
     this.register(DependencyInjectionTokens.Logger, new LoggerAdapter(), RegistryScope.SINGLETON);
   }
 }

--- a/src/configuration/dependency-registries/config-registries.ts
+++ b/src/configuration/dependency-registries/config-registries.ts
@@ -1,24 +1,23 @@
-import { instanceCachingFactory } from 'tsyringe';
-import { DependencyRegistry } from './dependency-registry';
+import { DependencyRegistry, RegistryScope } from './dependency-registry';
 import { DependencyInjectionTokens } from './tokens';
 import { LoggerAdapter } from '../logger/logger.adapter';
 
-function registerConfigs(this: DependencyRegistry): void {
+export interface DisableDefaultInstances {
+  loggerDisabled: boolean;
+}
+
+function registerConfigs(this: DependencyRegistry, disableDefaultInstances?: DisableDefaultInstances): void {
   /**
    * Registering useful instances
    *  Ref: https://github.com/microsoft/tsyringe#dependency-injection
    *
    * @matheusicaro
    */
-  this.container.register(DependencyInjectionTokens.Logger, {
-    /**
-     * Registering logger instance as a singleton
-     *  Ref: https://github.com/microsoft/tsyringe?tab=readme-ov-file#instancecachingfactory
-     *
-     * @matheusicaro
-     */
-    useFactory: instanceCachingFactory(() => new LoggerAdapter())
-  });
+
+  if (!disableDefaultInstances?.loggerDisabled) {
+    console.log('====> passed here', disableDefaultInstances?.loggerDisabled);
+    this.register(DependencyInjectionTokens.Logger, new LoggerAdapter(), RegistryScope.SINGLETON);
+  }
 }
 
 export { registerConfigs };

--- a/src/configuration/dependency-registries/config-registries.ts
+++ b/src/configuration/dependency-registries/config-registries.ts
@@ -15,7 +15,7 @@ function registerConfigs(this: DependencyRegistry, disableDefaultInstances?: Dis
    */
 
   if (!disableDefaultInstances?.loggerDisabled) {
-    this.register(DependencyInjectionTokens.Logger, new LoggerAdapter(), RegistryScope.SINGLETON);
+    this.register(RegistryScope.SINGLETON, DependencyInjectionTokens.Logger, new LoggerAdapter());
   }
 }
 

--- a/src/configuration/dependency-registries/dependency-registry.ts
+++ b/src/configuration/dependency-registries/dependency-registry.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 
-import { container, InjectionToken } from 'tsyringe';
+import { container, InjectionToken, instanceCachingFactory } from 'tsyringe';
 import { registerConfigs } from './config-registries';
 
 type DependencyRegistryArgs = (this: DependencyRegistry) => void;
@@ -28,6 +28,20 @@ class DependencyRegistry {
 
   resolve<T>(token: InjectionToken<T>): T {
     return this.container.resolve(token);
+  }
+
+  /**
+   * Register a single instance by instanceCachingFactory
+   *
+   * ref: https://github.com/microsoft/tsyringe?tab=readme-ov-file#instancecachingfactory
+   *
+   * @param token: tag that's identity the instance registered
+   * @param providerInstance: the provider instance, exe: registerInstanceCache(token, new ProviderInstance())
+   **/
+  registerInstanceCache<T>(token: string, providerInstance: T): void {
+    this.container.register(token, {
+      useFactory: instanceCachingFactory<T>((_container) => providerInstance)
+    });
   }
 }
 

--- a/src/configuration/dependency-registries/dependency-registry.ts
+++ b/src/configuration/dependency-registries/dependency-registry.ts
@@ -22,7 +22,7 @@ class DependencyRegistry {
   /**
    * @deprecated this reference will be removed soon, use getContainer() instead
    */
-  public container = container;
+  public container = container; // TODO: make this private in the release 2.0.0, cause it is a break changes
 
   constructor(registers: DependencyRegistryArgs[], disableDefaultInstances?: DisableDefaultInstances) {
     /**

--- a/src/configuration/dependency-registries/dependency-registry.ts
+++ b/src/configuration/dependency-registries/dependency-registry.ts
@@ -39,7 +39,7 @@ class DependencyRegistry {
     return this.container.resolve(token);
   }
 
-  register<T>(token: InjectionToken<T>, providerInstance: T, scope: RegistryScope): void {
+  register<T>(scope: RegistryScope, token: InjectionToken<T>, providerInstance: T): void {
     switch (scope) {
       case RegistryScope.SINGLETON:
         this.registerInstanceCache(token, providerInstance);

--- a/src/configuration/dependency-registries/dependency-registry.ts
+++ b/src/configuration/dependency-registries/dependency-registry.ts
@@ -22,7 +22,6 @@ class DependencyRegistry {
   private container = container;
 
   constructor(registers: DependencyRegistryArgs[], disableDefaultInstances?: DisableDefaultInstances) {
-    console.log(disableDefaultInstances);
     /**
      * registerConfigs defines the default dependencies available in this project @mi-node-framework
      **/

--- a/src/configuration/dependency-registries/dependency-registry.ts
+++ b/src/configuration/dependency-registries/dependency-registry.ts
@@ -7,7 +7,13 @@ import { InvalidArgumentError } from '../../errors';
 type DependencyRegistryArgs = (this: DependencyRegistry) => void;
 
 export enum RegistryScope {
+  /**
+   * Scope for singleton instances - same instance every time it is resolved
+   */
   SINGLETON = 'SINGLETON',
+  /**
+   * Scope for transient instances - a new instance every time it is resolved
+   */
   TRANSIENT_NON_SINGLETON = 'TRANSIENT'
 }
 

--- a/src/configuration/dependency-registries/dependency-registry.ts
+++ b/src/configuration/dependency-registries/dependency-registry.ts
@@ -19,7 +19,10 @@ export enum RegistryScope {
  * @matheusicaro
  */
 class DependencyRegistry {
-  private container = container;
+  /**
+   * @deprecated this reference will be removed soon, use getContainer() instead
+   */
+  public container = container;
 
   constructor(registers: DependencyRegistryArgs[], disableDefaultInstances?: DisableDefaultInstances) {
     /**

--- a/src/configuration/dependency-registries/index.ts
+++ b/src/configuration/dependency-registries/index.ts
@@ -1,3 +1,4 @@
+export * from 'tsyringe';
 export * from './dependency-registry';
 export * from './tokens';
 export * from './decorators';

--- a/src/configuration/logger/logger-base.ts
+++ b/src/configuration/logger/logger-base.ts
@@ -1,0 +1,101 @@
+import { ErrorBase } from '../..';
+import { LogData, LoggerPort, LogLevel } from './logger.port';
+import { createLoggerSetup } from './setup/create-logger.setup';
+
+interface ErrorInput {
+  message: string;
+  error?: Error | ErrorBase;
+  logData?: LogData;
+}
+
+/**
+ * LoggerBase is a base logger setup with a useful logger based on winston.
+ */
+abstract class LoggerBase implements LoggerPort {
+  private instance;
+
+  constructor() {
+    this.instance = createLoggerSetup();
+  }
+
+  /**
+   * Log a ErrorBase based on the error.logLevel
+   *
+   * @param message: custom message
+   * @param logData: any value/field to be logged
+   */
+  exception(error: ErrorBase): void {
+    switch (error.logLevel) {
+      case LogLevel.ERROR:
+        this.error({ message: error.message, error, logData: error.logData });
+        break;
+
+      case LogLevel.INFO:
+        this.info(error.message, error.logData);
+        break;
+
+      default:
+        throw new Error(`Log level ${error.logLevel} not implemented.`);
+    }
+  }
+
+  /**
+   * Log a message and log data as info
+   *
+   * @param message: custom message
+   * @param logData: any value/field to be logged
+   */
+  info(message: string, logData?: LogData): void {
+    const log = this.formatDataToBeLogged({ message, logData });
+
+    this.instance.info(JSON.stringify(log));
+  }
+
+  /**
+   * Log a message and log data as error
+   *
+   * @param message: custom message
+   * @param error: error to be logged
+   * @param logData: any value/field to be logged
+   */
+  error(input: ErrorInput): void {
+    this.instance.error(JSON.stringify(this.formatDataToBeLogged(input)));
+  }
+
+  /**
+   * Function to format the inputs to be logged.
+   *
+   * @returns {
+   *   "message":"fail here 2",
+   *   "logData":{
+   *      ...{input.logData},
+   *      "originalError": {
+   *        "message":"original error message",
+   *        "stack":"Error: original error message\n  at Timeout._onTimeout (...service/src/server.ts:32:14)..."
+   *      }
+   *  }
+   * }
+   */
+  private formatDataToBeLogged(input: ErrorInput) {
+    const errorData = {
+      ...(input.error && {
+        originalError: {
+          message: input.error.message,
+          stack: input.error.stack || 'undefined'
+        }
+      })
+    };
+
+    const logData = {
+      ...(input.logData && input.logData),
+      ...errorData
+    };
+
+    return {
+      message: input.message,
+      logData
+    };
+  }
+}
+
+export { LoggerBase };

--- a/src/configuration/logger/logger.adapter.ts
+++ b/src/configuration/logger/logger.adapter.ts
@@ -1,87 +1,12 @@
-import { ErrorBase } from '../../';
-import { LogData, LoggerPort, LogLevel } from './logger.port';
-import { createLoggerSetup } from './setup/create-logger.setup';
+import { LoggerBase } from './logger-base';
+import { LoggerPort } from './logger.port';
 
-interface ErrorInput {
-  message: string;
-  error?: Error | ErrorBase;
-  logData?: LogData;
-}
-
-class LoggerAdapter implements LoggerPort {
-  private instance;
-
+/**
+ * LoggerAdapter to be injected as a default configs for the framework
+ */
+class LoggerAdapter extends LoggerBase implements LoggerPort {
   constructor() {
-    this.instance = createLoggerSetup();
-  }
-
-  public exception(error: ErrorBase): void {
-    switch (error.logLevel) {
-      case LogLevel.ERROR:
-        this.error({ message: error.message, error, logData: error.logData });
-        break;
-
-      case LogLevel.INFO:
-        this.info(error.message, error.logData);
-        break;
-
-      default:
-        throw new Error(`Log level ${error.logLevel} not implemented.`);
-    }
-  }
-
-  /**
-   * @param message: custom message
-   * @param logData: any value/field to be logged
-   */
-  public info(message: string, logData?: LogData): void {
-    const log = this.formatDataToBeLogged({ message, logData });
-
-    this.instance.info(JSON.stringify(log));
-  }
-
-  /**
-   * @param message: custom message
-   * @param error: error to be logged
-   * @param logData: any value/field to be logged
-   */
-  public error(input: ErrorInput): void {
-    this.instance.error(JSON.stringify(this.formatDataToBeLogged(input)));
-  }
-
-  /**
-   * Function to format the inputs to be logged.
-   *
-   * @returns {
-   *   "message":"fail here 2",
-   *   "logData":{
-   *      ...{input.logData},
-   *      "originalError": {
-   *        "message":"original error message",
-   *        "stack":"Error: original error message\n  at Timeout._onTimeout (...service/src/server.ts:32:14)..."
-   *      }
-   *  }
-   * }
-   */
-  private formatDataToBeLogged(input: ErrorInput) {
-    const errorData = {
-      ...(input.error && {
-        originalError: {
-          message: input.error.message,
-          stack: input.error.stack || 'undefined'
-        }
-      })
-    };
-
-    const logData = {
-      ...(input.logData && input.logData),
-      ...errorData
-    };
-
-    return {
-      message: input.message,
-      logData
-    };
+    super();
   }
 }
 

--- a/tests/configuration/dependency-registries/dependency-registry.test.ts
+++ b/tests/configuration/dependency-registries/dependency-registry.test.ts
@@ -1,15 +1,96 @@
-/**
- * TODO: implement tests for DependencyRegistry
- *     - issue: https://github.com/matheusicaro/mi-node-framework/issues/6
- */
+import { DependencyRegistry } from '../../../src/';
+import { LoggerAdapter } from '../../../src/configuration/logger/logger.adapter';
+
 describe('DependencyRegistry', () => {
   describe('constructor', () => {
-    test('should register the default dependencies', () => {});
+    test('should register the default dependencies', () => {
+      const dependencyRegistry = new DependencyRegistry([]);
 
-    test('should register the dependencies passed as arguments', () => {});
+      expect(dependencyRegistry.container.resolve('Logger')).toBeInstanceOf(LoggerAdapter);
+    });
+
+    test('should register the dependencies passed as arguments', () => {
+      class TestA {}
+      class TestB {}
+
+      function registerCustomDependenciesTypeA(this: DependencyRegistry): void {
+        this.container.register('TestA', {
+          useValue: new TestA()
+        });
+      }
+
+      function registerCustomDependenciesTypeB(this: DependencyRegistry): void {
+        this.container.register('TestB', {
+          useValue: new TestB()
+        });
+      }
+
+      const dependencyRegistry = new DependencyRegistry([
+        registerCustomDependenciesTypeA,
+        registerCustomDependenciesTypeB
+      ]);
+
+      expect(dependencyRegistry.container.resolve('Logger')).toBeInstanceOf(LoggerAdapter);
+      expect(dependencyRegistry.container.resolve('TestA')).toBeInstanceOf(TestA);
+      expect(dependencyRegistry.container.resolve('TestB')).toBeInstanceOf(TestB);
+    });
   });
 
   describe('resolve', () => {
-    test('should resolve the correct dependency from the token', () => {});
+    test('should resolve the correct dependency from the token', () => {
+      class TestA {}
+
+      function registerCustomDependenciesTypeA(this: DependencyRegistry): void {
+        this.container.register('TestA', {
+          useValue: new TestA()
+        });
+      }
+      const dependencyRegistry = new DependencyRegistry([registerCustomDependenciesTypeA]);
+
+      expect(dependencyRegistry.resolve('TestA')).toBeInstanceOf(TestA);
+    });
+  });
+
+  describe('registerInstanceCache', () => {
+    const dependencyRegistry = new DependencyRegistry([]);
+
+    class SingletonClass {
+      private counter = 0;
+      private calls = 0;
+
+      constructor() {
+        this.counter++;
+      }
+
+      public getCounter() {
+        this.calls++;
+
+        return this.counter;
+      }
+
+      public getCounterCalls() {
+        return this.calls;
+      }
+    }
+
+    dependencyRegistry.registerInstanceCache('SingletonClass', new SingletonClass());
+
+    test.each([1, 2, 3, 4, 5])(
+      'should register dependency as a singleton correctly when called for the %s times',
+      (times) => {
+        const instance = dependencyRegistry.resolve<SingletonClass>('SingletonClass');
+
+        /**
+         * Every time a instance is created the count is incremented.
+         * As a singleton class, the counter should always be 1
+         */
+        expect(instance.getCounter()).toEqual(1);
+        /**
+         * When getCounter() is called, the calls is registered by increment the calls field
+         * As a singleton class, getCounterCalls() should always return the total of getCounter() calls
+         */
+        expect(instance.getCounterCalls()).toEqual(times);
+      }
+    );
   });
 });

--- a/tests/configuration/dependency-registries/dependency-registry.test.ts
+++ b/tests/configuration/dependency-registries/dependency-registry.test.ts
@@ -30,11 +30,11 @@ describe('DependencyRegistry', () => {
       class TestB {}
 
       function registerCustomDependenciesTypeA(this: DependencyRegistry): void {
-        this.register('TestA', new TestA(), RegistryScope.TRANSIENT_NON_SINGLETON);
+        this.register(RegistryScope.TRANSIENT_NON_SINGLETON, 'TestA', new TestA());
       }
 
       function registerCustomDependenciesTypeB(this: DependencyRegistry): void {
-        this.register('TestB', new TestB(), RegistryScope.SINGLETON);
+        this.register(RegistryScope.SINGLETON, 'TestB', new TestB());
       }
 
       const dependencyRegistry = new DependencyRegistry([
@@ -54,7 +54,7 @@ describe('DependencyRegistry', () => {
     test('should resolve the correct dependency from the token', () => {
       class TestA {}
       function registerCustomDependenciesTypeA(this: DependencyRegistry): void {
-        this.register('TestA', new TestA(), RegistryScope.TRANSIENT_NON_SINGLETON);
+        this.register(RegistryScope.TRANSIENT_NON_SINGLETON, 'TestA', new TestA());
       }
       const dependencyRegistry = new DependencyRegistry([registerCustomDependenciesTypeA]);
       expect(dependencyRegistry.resolve('TestA')).toBeInstanceOf(TestA);
@@ -85,8 +85,8 @@ describe('DependencyRegistry', () => {
 
     const dependencyRegistry = new DependencyRegistry([]);
 
-    dependencyRegistry.register('TransientClass', new ExampleClass(), RegistryScope.TRANSIENT_NON_SINGLETON);
-    dependencyRegistry.register('SingletonClass', new ExampleClass(), RegistryScope.SINGLETON);
+    dependencyRegistry.register(RegistryScope.TRANSIENT_NON_SINGLETON, 'TransientClass', new ExampleClass());
+    dependencyRegistry.register(RegistryScope.SINGLETON, 'SingletonClass', new ExampleClass());
 
     describe.each(totalResolvingClass)('when the registered dependency is resolved for the %s times', (times) => {
       //
@@ -124,7 +124,7 @@ describe('DependencyRegistry', () => {
 
     test('should throw error when scope is not available', () => {
       const registerNoScopeClass = () => {
-        return dependencyRegistry.register('NoScope', new ExampleClass(), 'ANY' as RegistryScope);
+        return dependencyRegistry.register('ANY' as RegistryScope, 'NoScope', new ExampleClass());
       };
 
       expect(registerNoScopeClass).toThrow(

--- a/tests/errors/invalid-argument.error.test.ts
+++ b/tests/errors/invalid-argument.error.test.ts
@@ -10,8 +10,6 @@ describe('InvalidArgumentError', () => {
     test('should set the default fields correctly when only message is passed', () => {
       const error = new InvalidArgumentError('error');
 
-      console.log(error.name);
-
       expect(error.message).toEqual('error');
       expect(error.code).toEqual(ErrorCode.INVALID_ARGUMENT);
       expect(error.isErrorBase).toEqual(true);

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": [
     "../src/**/*",
+    "./*"
   ],
   "exclude": [
     "./jest.setup.ts",


### PR DESCRIPTION
# Description

- Added an easy method to register a singleton instance by `register(SCOPE, token, instance)`
- Exporting Abstract logger to be extended when needed

# How did you test?

- [x] Were the changes tested locally by linking the draft to another project?
- [x] Was released a `next` version for validation released [1.1.0-next.1](link)?

# Checklist

- [x] Updated docs
- [x] Added unit tests or created an issue for future work